### PR TITLE
Show case HtmlStringable functionality.

### DIFF
--- a/src/Html/HtmlStringable.php
+++ b/src/Html/HtmlStringable.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Markup\Html;
+
+use Stringable;
+
+interface HtmlStringable extends Stringable {
+}

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Markup\View\Helper;
+
+use Cake\View\Helper\FormHelper as CoreFormHelper;
+use Markup\Html\HtmlStringable;
+
+class FormHelper extends CoreFormHelper {
+
+	/**
+	 * @param string|\Markup\Html\HtmlStringable $title
+	 * @param array|string|null $url
+	 * @param array $options
+	 *
+	 * @return string
+	 */
+	public function postLink(string|HtmlStringable $title, array|string|null $url = null, array $options = []): string {
+		if ($title instanceof HtmlStringable) {
+			$options['escapeTitle'] = false;
+			$title = (string)$title;
+		}
+
+		return parent::postLink($title, $url, $options);
+	}
+
+	/**
+	 * @param string|\Markup\Html\HtmlStringable $title
+	 * @param array|string $url
+	 * @param array $options
+	 *
+	 * @return string
+	 */
+	public function postButton(string|HtmlStringable $title, array|string $url, array $options = []): string {
+		if ($title instanceof HtmlStringable) {
+			$options['escapeTitle'] = false;
+			$title = (string)$title;
+		}
+
+		return parent::postButton($title, $url, $options);
+	}
+
+}

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -8,7 +8,7 @@ use Markup\Html\HtmlStringable;
 class FormHelper extends CoreFormHelper {
 
 	/**
-	 * @param string|\Markup\Html\HtmlStringable $title
+	 * @param \Markup\Html\HtmlStringable|string $title
 	 * @param array|string|null $url
 	 * @param array $options
 	 *
@@ -24,7 +24,7 @@ class FormHelper extends CoreFormHelper {
 	}
 
 	/**
-	 * @param string|\Markup\Html\HtmlStringable $title
+	 * @param \Markup\Html\HtmlStringable|string $title
 	 * @param array|string $url
 	 * @param array $options
 	 *

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Markup\View\Helper;
+
+use Cake\View\Helper\HtmlHelper as CoreHtmlHelper;
+use Markup\Html\HtmlStringable;
+
+class HtmlHelper extends CoreHtmlHelper {
+
+	/**
+	 * @param \Markup\Html\HtmlStringable|array|string $title
+	 * @param array|string|null $url
+	 * @param array $options
+	 *
+	 * @return string
+	 */
+	public function link(array|string|HtmlStringable $title, array|string|null $url = null, array $options = []): string {
+		if ($title instanceof HtmlStringable) {
+			$options['escapeTitle'] = false;
+			$title = (string)$title;
+		}
+
+		return parent::link($title, $url, $options);
+	}
+
+	public function linkFromPath(string|HtmlStringable $title, string $path, array $params = [], array $options = []): string {
+		if ($title instanceof HtmlStringable) {
+			$options['escapeTitle'] = false;
+			$title = (string)$title;
+		}
+
+		return parent::linkFromPath($title, $path, $params, $options);
+	}
+
+}

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -23,6 +23,14 @@ class HtmlHelper extends CoreHtmlHelper {
 		return parent::link($title, $url, $options);
 	}
 
+	/**
+	 * @param \Markup\Html\HtmlStringable|string $title
+	 * @param string $path
+	 * @param array $params
+	 * @param array $options
+	 *
+	 * @return string
+	 */
 	public function linkFromPath(string|HtmlStringable $title, string $path, array $params = [], array $options = []): string {
 		if ($title instanceof HtmlStringable) {
 			$options['escapeTitle'] = false;

--- a/src/View/HtmlStringTrait.php
+++ b/src/View/HtmlStringTrait.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Markup\View;
+
+/**
+ * Transforms and works with HtmlStringable value objects.
+ */
+trait HtmlStringTrait {
+}

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -50,7 +50,10 @@ class HtmlHelperTest extends TestCase {
 	public function testLink() {
 		$icon = new class implements HtmlStringable {
 
-			function __toString(): string {
+			/**
+			 * @return string
+			 */
+			public function __toString(): string {
 				return '<span>Some ICON HTML</span>';
 			}
 		};

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Markup\Test\TestCase\View\Helper;
+
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+use Markup\Html\HtmlStringable;
+use Markup\View\Helper\HtmlHelper;
+
+class HtmlHelperTest extends TestCase {
+
+	/**
+	 * @var \Markup\View\Helper\HtmlHelper
+	 */
+	protected $helper;
+
+	/**
+	 * @var \Cake\Http\ServerRequest
+	 */
+	protected $request;
+
+	/**
+	 * setUp method
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->request = new ServerRequest();
+		$view = new View($this->request);
+		$this->helper = new HtmlHelper($view);
+	}
+
+	/**
+	 * tearDown method
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		unset($this->helper);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testLink() {
+		$icon = new class implements HtmlStringable {
+
+			function __toString(): string {
+				return '<span>Some ICON HTML</span>';
+			}
+		};
+
+		$result = $this->helper->link($icon, '/');
+		$expected = '<a href="/"><span>Some ICON HTML</span></a>';
+		$this->assertSame($expected, $result);
+	}
+
+}


### PR DESCRIPTION
With this we can use more value objects inside the app and plugins which know how to use escaping or not
This way, we would need less manual working with escapeTitle and alike in the calls to the helpers.

What do people think?
```php
$this->Html->link($iconObject, '/');
$this->Form->postLink($iconObject, '/');
```
etc
```html
<a href="/"><span>Some ICON HTML</span></a>
...
```