### PR TITLE
Fix PHPStan errors from CakePHP 5.3.0 View generic types

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,4 @@ parameters:
 	ignoreErrors:
 		- '#Call to static method createGFMEnvironment\(\) on an unknown class .+Environment#'
 		- '#Class .+CommonMarkConverter constructor invoked with 2 parameters, 0-1 required#'
+		- identifier: missingType.generics

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,4 +7,3 @@ parameters:
 	ignoreErrors:
 		- '#Call to static method createGFMEnvironment\(\) on an unknown class .+Environment#'
 		- '#Class .+CommonMarkConverter constructor invoked with 2 parameters, 0-1 required#'
-		- identifier: missingType.generics

--- a/src/View/DjotView.php
+++ b/src/View/DjotView.php
@@ -44,6 +44,8 @@ use Markup\Djot\DjotMarkup;
  * Configure via `Configure::write('Djot', [...])` or pass options to the view:
  * - `safeMode`: Enable XSS protection (default: true)
  * - `converter`: Custom converter class implementing DjotInterface
+ *
+ * @extends \Cake\View\View<\Markup\View\DjotView>
  */
 class DjotView extends View {
 

--- a/src/View/Helper/BbcodeHelper.php
+++ b/src/View/Helper/BbcodeHelper.php
@@ -8,6 +8,9 @@ use Cake\View\View;
 use InvalidArgumentException;
 use Markup\Bbcode\DecodaBbcode;
 
+/**
+ * @template TView of \Cake\View\View
+ */
 class BbcodeHelper extends Helper {
 
 	/**
@@ -31,7 +34,7 @@ class BbcodeHelper extends Helper {
 	/**
 	 * Constructor
 	 *
-	 * @param \Cake\View\View $View The View this helper is being attached to.
+	 * @param \Cake\View\View<TView> $View The View this helper is being attached to.
 	 * @param array<string, mixed> $config Configuration settings for the helper.
 	 */
 	public function __construct(View $View, array $config = []) {

--- a/src/View/Helper/DjotHelper.php
+++ b/src/View/Helper/DjotHelper.php
@@ -14,6 +14,7 @@ use Markup\Djot\DjotMarkup;
  * Djot is a modern markup language created by John MacFarlane (author of CommonMark/Pandoc).
  *
  * @link https://djot.net/ Djot specification
+ * @template TView of \Cake\View\View
  */
 class DjotHelper extends Helper {
 
@@ -50,7 +51,7 @@ class DjotHelper extends Helper {
 	/**
 	 * Constructor
 	 *
-	 * @param \Cake\View\View $View The View this helper is being attached to.
+	 * @param \Cake\View\View<TView> $View The View this helper is being attached to.
 	 * @param array<string, mixed> $config Configuration settings for the helper.
 	 */
 	public function __construct(View $View, array $config = []) {

--- a/src/View/Helper/HighlighterHelper.php
+++ b/src/View/Helper/HighlighterHelper.php
@@ -7,6 +7,9 @@ use Cake\View\Helper;
 use Cake\View\View;
 use Markup\Highlighter\PhpHighlighter;
 
+/**
+ * @template TView of \Cake\View\View
+ */
 class HighlighterHelper extends Helper {
 
 	/**
@@ -30,7 +33,7 @@ class HighlighterHelper extends Helper {
 	/**
 	 * Constructor
 	 *
-	 * @param \Cake\View\View $View The View this helper is being attached to.
+	 * @param \Cake\View\View<TView> $View The View this helper is being attached to.
 	 * @param array<string, mixed> $config Configuration settings for the helper.
 	 */
 	public function __construct(View $View, array $config = []) {

--- a/src/View/Helper/MarkdownHelper.php
+++ b/src/View/Helper/MarkdownHelper.php
@@ -20,6 +20,7 @@ use Markup\Markdown\CommonMarkMarkdown;
  * echo $this->Markdown->convert($markdownText);
  * ```
  *
+ * @template TView of \Cake\View\View
  * @author Mark Scherer
  * @license MIT
  */
@@ -46,7 +47,7 @@ class MarkdownHelper extends Helper {
 	/**
 	 * Constructor
 	 *
-	 * @param \Cake\View\View $View The View this helper is being attached to.
+	 * @param \Cake\View\View<TView> $View The View this helper is being attached to.
 	 * @param array<string, mixed> $config Configuration settings for the helper.
 	 */
 	public function __construct(View $View, array $config = []) {


### PR DESCRIPTION
## Summary

- Fix PHPStan CI failures caused by CakePHP 5.3.0 adding generic type parameters to the View class
- Add proper `@template` annotations to helper classes
- Add `@extends` annotation to DjotView

This started failing after CakePHP 5.3.0 release on Jan 10.