### PR TITLE
Harden CommonMark/Djot XSS defaults

### DIFF
--- a/src/Djot/DjotMarkup.php
+++ b/src/Djot/DjotMarkup.php
@@ -19,9 +19,19 @@ class DjotMarkup implements DjotInterface {
 	use InstanceConfigTrait;
 
 	/**
+	 * Cached converter, keyed by the hash of options used to build it.
+	 * Per-call options that differ from the cached key trigger a rebuild,
+	 * preventing a `safeMode=false` instance from serving a later call that
+	 * requested `safeMode=true` — a real risk in long-lived FPM/queue workers.
+	 *
 	 * @var \Djot\DjotConverter|null
 	 */
 	protected ?DjotConverter $converter = null;
+
+	/**
+	 * @var string|null
+	 */
+	protected ?string $converterKey = null;
 
 	/**
 	 * Default configuration.
@@ -71,8 +81,8 @@ class DjotMarkup implements DjotInterface {
 	 * @return \Djot\DjotConverter
 	 */
 	protected function converter(array $options): DjotConverter {
-		// Create new converter if options differ from cached one
-		if ($this->converter === null) {
+		$key = md5(serialize($options));
+		if ($this->converter === null || $this->converterKey !== $key) {
 			$profile = $this->resolveProfile($options['profile'] ?? null);
 
 			$this->converter = new DjotConverter(
@@ -82,6 +92,7 @@ class DjotMarkup implements DjotInterface {
 				safeMode: $options['safeMode'] ?? true,
 				profile: $profile,
 			);
+			$this->converterKey = $key;
 		}
 
 		return $this->converter;

--- a/src/Markdown/CommonMarkMarkdown.php
+++ b/src/Markdown/CommonMarkMarkdown.php
@@ -16,9 +16,18 @@ class CommonMarkMarkdown implements MarkdownInterface {
 	use InstanceConfigTrait;
 
 	/**
+	 * Cached converter, keyed by the hash of options used to build it.
+	 * Per-call options that differ from the cached key trigger a rebuild,
+	 * preventing the unsafe variant from being served when callers ask for safe.
+	 *
 	 * @var \League\CommonMark\MarkdownConverterInterface|null
 	 */
-	protected $converter;
+	protected ?MarkdownConverterInterface $converter = null;
+
+	/**
+	 * @var string|null
+	 */
+	protected ?string $converterKey = null;
 
 	/**
 	 * @var array<string, mixed>
@@ -45,19 +54,36 @@ class CommonMarkMarkdown implements MarkdownInterface {
 	}
 
 	/**
+	 * Returns the converter instance, rebuilding it when the supplied options
+	 * differ from those that produced the cached one. Without this check, the
+	 * first call would pin safe/unsafe behavior for the lifetime of the
+	 * instance — a real risk in long-lived FPM/queue workers.
+	 *
 	 * @param array<string, mixed> $options
 	 *
 	 * @return \League\CommonMark\MarkdownConverterInterface
 	 */
 	protected function converter(array $options = []): MarkdownConverterInterface {
-		if ($this->converter === null) {
+		$key = md5(serialize($options));
+		if ($this->converter === null || $this->converterKey !== $key) {
 			$this->converter = static::defaultConverter($options);
+			$this->converterKey = $key;
 		}
 
 		return $this->converter;
 	}
 
 	/**
+	 * Builds a fresh CommonMark converter.
+	 *
+	 * Defaults are safe-by-default:
+	 * - `escape` => true: maps to CommonMark's `html_input => 'escape'`, so raw
+	 *   HTML in the source is escaped instead of rendered.
+	 * - `allow_unsafe_links` => false: blocks dangerous URL schemes such as
+	 *   `javascript:`, `data:`, `vbscript:` from passing through `[link](...)`
+	 *   and `![image](...)`. CommonMark 1.x defaulted this to true, so the
+	 *   override matters when composer resolves a 1.x line.
+	 *
 	 * @param array<string, mixed> $options
 	 *
 	 * @return \League\CommonMark\MarkdownConverterInterface
@@ -65,6 +91,7 @@ class CommonMarkMarkdown implements MarkdownInterface {
 	public static function defaultConverter(array $options = []): MarkdownConverterInterface {
 		$options += [
 			'escape' => true,
+			'allow_unsafe_links' => false,
 		];
 		if ($options['escape']) {
 			$options['html_input'] = 'escape';

--- a/tests/TestCase/Djot/DjotMarkupTest.php
+++ b/tests/TestCase/Djot/DjotMarkupTest.php
@@ -93,6 +93,24 @@ TEXT;
 	}
 
 	/**
+	 * The converter must be rebuilt when per-call options differ from the
+	 * cached one. Otherwise the first call's safeMode would be pinned for the
+	 * lifetime of the instance — a real XSS regression vector under long-lived
+	 * FPM/queue workers.
+	 *
+	 * @return void
+	 */
+	public function testConverterRebuildsWhenOptionsChange(): void {
+		$text = "[click](javascript:alert('xss'))";
+
+		$first = $this->djot->convert($text, ['safeMode' => false]);
+		$this->assertStringContainsString('javascript:', $first);
+
+		$second = $this->djot->convert($text, ['safeMode' => true]);
+		$this->assertStringNotContainsString('javascript:', $second);
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testConvertRawHtml(): void {

--- a/tests/TestCase/Markdown/CommonMarkMarkdownTest.php
+++ b/tests/TestCase/Markdown/CommonMarkMarkdownTest.php
@@ -82,4 +82,47 @@ TXT;
 		$this->assertSame($expected, $result);
 	}
 
+	/**
+	 * Defaults must neutralize the `javascript:` URL scheme on links and images
+	 * so `[click](javascript:alert(1))` cannot escape into a usable href.
+	 *
+	 * @return void
+	 */
+	public function testConvertNeutralizesJavascriptLinks(): void {
+		$text = "[click](javascript:alert(1))\n\n![x](javascript:alert(1))";
+
+		$result = $this->markdown->convert($text);
+		$this->assertStringNotContainsString('javascript:', $result);
+	}
+
+	/**
+	 * Defaults must neutralize `data:` URLs which can carry inline HTML/JS.
+	 *
+	 * @return void
+	 */
+	public function testConvertNeutralizesDataLinks(): void {
+		$text = '[click](data:text/html,<script>alert(1)</script>)';
+
+		$result = $this->markdown->convert($text);
+		$this->assertStringNotContainsString('data:text/html', $result);
+		$this->assertStringNotContainsString('<script', $result);
+	}
+
+	/**
+	 * The converter must be rebuilt when per-call options differ from the
+	 * cached one. Otherwise the first call's safety setting would be pinned
+	 * for the lifetime of the instance — a real XSS regression vector under
+	 * long-lived FPM/queue workers.
+	 *
+	 * @return void
+	 */
+	public function testConverterRebuildsWhenOptionsChange(): void {
+		$first = $this->markdown->convert('<b>x</b>', ['escape' => true]);
+		$this->assertStringContainsString('&lt;b&gt;', $first);
+
+		$second = $this->markdown->convert('<b>x</b>', ['escape' => false]);
+		$this->assertStringContainsString('<b>x</b>', $second);
+		$this->assertStringNotContainsString('&lt;b&gt;', $second);
+	}
+
 }


### PR DESCRIPTION
## Summary

Two small, mechanical XSS-hardening fixes to the Markdown and Djot backends. Both are real risks under long-lived FPM / queue workers.

### 1. CommonMark: safe URL schemes by default

\`CommonMarkMarkdown::defaultConverter()\` only configured \`html_input => 'escape'\` (mapped from the \`escape\` option). The separate \`allow_unsafe_links\` knob was left untouched, so:

- On league/commonmark 1.x (still allowed by composer.json: \`^1.5 || ^2.0\`) the library default is \`true\` — \`[click](javascript:alert(1))\` and \`![x](javascript:alert(1))\` pass through with their \`javascript:\` href intact.
- On 2.x the library default is \`false\`, but the override is now explicit so a downstream consumer cannot accidentally re-enable it.

Defaults to \`allow_unsafe_links => false\`; callers can still pass \`true\` explicitly via \`$options\`.

### 2. CommonMark + Djot: rebuild converter when options change

Both \`CommonMarkMarkdown::converter()\` and \`DjotMarkup::converter()\` cached the converter on the first call and ignored later \`$options\` differences. Concretely:

\`\`\`php
\$djot->convert(\$untrustedA, ['safeMode' => false]); // builds unsafe converter
\$djot->convert(\$untrustedB, ['safeMode' => true]);  // SERVED BY THE UNSAFE ONE
\`\`\`

Under FPM workers and queue workers (which re-use the same plugin instance across many requests/jobs), this is a real "first request poisons later requests" XSS path.

Fix: hash \`md5(serialize(\$options))\` and rebuild when the key changes. The converters are cheap to construct.

### Tests

- \`CommonMarkMarkdownTest::testConvertNeutralizesJavascriptLinks\` — \`javascript:\` neutralized in link + image by default.
- \`CommonMarkMarkdownTest::testConvertNeutralizesDataLinks\` — \`data:text/html\` payload neutralized by default.
- \`CommonMarkMarkdownTest::testConverterRebuildsWhenOptionsChange\` — flipping \`escape\` between calls produces correct output for each call.
- \`DjotMarkupTest::testConverterRebuildsWhenOptionsChange\` — flipping \`safeMode\` between calls correctly neutralizes \`javascript:\` on the safe call after an unsafe call.

All existing 35 tests still pass; phpstan level 8 clean; phpcs clean.