### PR TITLE
Apply conservative Rector cleanup

### DIFF
--- a/src/Bbcode/Decoda/VideoFilter.php
+++ b/src/Bbcode/Decoda/VideoFilter.php
@@ -54,7 +54,7 @@ class VideoFilter extends AbstractFilter {
 		$provider = $tag['attributes']['default'] ?? $tag['tag'];
 		//$size = mb_strtolower(isset($tag['attributes']['size']) ? $tag['attributes']['size'] : 'medium');
 
-		if (preg_match('/^\[video\s*=\s*([a-z0-9_-]+)\]$/i', $tag['text'], $matches) !== 1) {
+		if (preg_match('/^\[video\s*=\s*([a-z0-9_-]+)\]$/i', (string) $tag['text'], $matches) !== 1) {
 			return $tag['text'] . $content . '[/' . $tag['tag'] . ']';
 		}
 
@@ -76,7 +76,7 @@ class VideoFilter extends AbstractFilter {
 	protected function transform($provider, $id) {
 		// timestamp?
 		$t = null;
-		if (strpos($id, ',') !== false) {
+		if (str_contains($id, ',')) {
 			[$id, $t] = explode(',', $id, 2);
 		}
 		if ($t) {

--- a/src/Bbcode/Decoda/VideoFilter.php
+++ b/src/Bbcode/Decoda/VideoFilter.php
@@ -54,7 +54,7 @@ class VideoFilter extends AbstractFilter {
 		$provider = $tag['attributes']['default'] ?? $tag['tag'];
 		//$size = mb_strtolower(isset($tag['attributes']['size']) ? $tag['attributes']['size'] : 'medium');
 
-		if (preg_match('/^\[video\s*=\s*([a-z0-9_-]+)\]$/i', (string) $tag['text'], $matches) !== 1) {
+		if (preg_match('/^\[video\s*=\s*([a-z0-9_-]+)\]$/i', (string)$tag['text'], $matches) !== 1) {
 			return $tag['text'] . $content . '[/' . $tag['tag'] . ']';
 		}
 

--- a/src/Djot/DjotMarkup.php
+++ b/src/Djot/DjotMarkup.php
@@ -82,7 +82,7 @@ class DjotMarkup implements DjotInterface {
 	 */
 	protected function converter(array $options): DjotConverter {
 		$key = md5(serialize($options));
-		if ($this->converter === null || $this->converterKey !== $key) {
+		if (!$this->converter instanceof \Djot\DjotConverter || $this->converterKey !== $key) {
 			$profile = $this->resolveProfile($options['profile'] ?? null);
 
 			$this->converter = new DjotConverter(

--- a/src/Djot/DjotMarkup.php
+++ b/src/Djot/DjotMarkup.php
@@ -82,7 +82,7 @@ class DjotMarkup implements DjotInterface {
 	 */
 	protected function converter(array $options): DjotConverter {
 		$key = md5(serialize($options));
-		if (!$this->converter instanceof \Djot\DjotConverter || $this->converterKey !== $key) {
+		if (!$this->converter instanceof DjotConverter || $this->converterKey !== $key) {
 			$profile = $this->resolveProfile($options['profile'] ?? null);
 
 			$this->converter = new DjotConverter(

--- a/src/Markdown/CommonMarkMarkdown.php
+++ b/src/Markdown/CommonMarkMarkdown.php
@@ -65,7 +65,7 @@ class CommonMarkMarkdown implements MarkdownInterface {
 	 */
 	protected function converter(array $options = []): MarkdownConverterInterface {
 		$key = md5(serialize($options));
-		if (!$this->converter instanceof \League\CommonMark\MarkdownConverterInterface || $this->converterKey !== $key) {
+		if (!$this->converter instanceof MarkdownConverterInterface || $this->converterKey !== $key) {
 			$this->converter = static::defaultConverter($options);
 			$this->converterKey = $key;
 		}

--- a/src/Markdown/CommonMarkMarkdown.php
+++ b/src/Markdown/CommonMarkMarkdown.php
@@ -65,7 +65,7 @@ class CommonMarkMarkdown implements MarkdownInterface {
 	 */
 	protected function converter(array $options = []): MarkdownConverterInterface {
 		$key = md5(serialize($options));
-		if ($this->converter === null || $this->converterKey !== $key) {
+		if (!$this->converter instanceof \League\CommonMark\MarkdownConverterInterface || $this->converterKey !== $key) {
 			$this->converter = static::defaultConverter($options);
 			$this->converterKey = $key;
 		}

--- a/src/View/DjotView.php
+++ b/src/View/DjotView.php
@@ -96,7 +96,7 @@ class DjotView extends View {
 	 * @return \Markup\Djot\DjotInterface
 	 */
 	protected function _getConverter(): DjotInterface {
-		if ($this->_converter !== null) {
+		if ($this->_converter instanceof \Markup\Djot\DjotInterface) {
 			return $this->_converter;
 		}
 

--- a/src/View/DjotView.php
+++ b/src/View/DjotView.php
@@ -96,7 +96,7 @@ class DjotView extends View {
 	 * @return \Markup\Djot\DjotInterface
 	 */
 	protected function _getConverter(): DjotInterface {
-		if ($this->_converter instanceof \Markup\Djot\DjotInterface) {
+		if ($this->_converter instanceof DjotInterface) {
 			return $this->_converter;
 		}
 


### PR DESCRIPTION
Applies the same conservative, behavior-neutral Rector cleanup pass as used in dereuromark/cakephp-ide-helper#452, but without committing Rector config or dependency wiring here.

- dead-code and code-quality simplifications only
- excludes the same unsafe / opinionated ruleset areas
- keeps the PR scope to generated cleanup changes in `src/` and `tests/`

This was generated with a temporary local Rector config and followed with CS fixes where needed.