### PR TITLE
Add Carve markup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A CakePHP plugin to
 - quickly convert Markdown snippets.
 - quickly convert BBCode snippets.
 - quickly convert Djot snippets.
+- quickly convert Carve snippets.
 
 This branch is for **CakePHP 5.1+**. See [version map](https://github.com/dereuromark/cakephp-markup/wiki#cakephp-version-map) for details.
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
 		"league/commonmark": "^1.5 || ^2.0",
 		"mjohnson/decoda": "^6.12",
 		"php-collective/djot": "^0.1.30",
-		"phpunit/phpunit": "^11.5 || ^12.1 || ^13.0"
+		"phpunit/phpunit": "^11.5 || ^12.1 || ^13.0",
+		"markup-carve/carve-php": "dev-main"
 	},
 	"minimum-stability": "stable",
 	"prefer-stable": true,

--- a/config/app.example.php
+++ b/config/app.example.php
@@ -49,6 +49,22 @@ return [
 		'profile' => null,
 	],
 
+	// Read by Markup\View\Helper\CarveHelper.
+	'Carve' => [
+		// Converter class implementing Markup\Carve\CarveInterface.
+		// Default: Markup\Carve\CarveMarkup.
+		'converter' => \Markup\Carve\CarveMarkup::class,
+		// Append timing info to output. null = follow app `debug`. Default: null.
+		'debug' => null,
+		// Enable XSS protection (blocks dangerous URLs, filters attributes). Default: true.
+		'safeMode' => true,
+		// Output XHTML-compatible markup. Default: false.
+		'xhtml' => false,
+		// Profile name ('full', 'article', 'comment', 'minimal') or Profile instance that
+		// restricts which markup features are allowed. null = all features. Default: null.
+		'profile' => null,
+	],
+
 	// Read by Markup\View\Helper\MarkdownHelper.
 	'Markdown' => [
 		// Converter class implementing Markup\Markdown\MarkdownInterface.

--- a/docs/Carve.md
+++ b/docs/Carve.md
@@ -1,0 +1,114 @@
+# Carve
+
+Convert [Carve](https://github.com/markup-carve/carve) markup to HTML using [markup-carve/carve-php](https://github.com/markup-carve/carve-php).
+
+Carve is a post-Markdown lightweight markup language with visual mnemonics and human-centered design.
+The PHP implementation is a hard fork of [djot-php](https://github.com/php-collective/djot-php), so it shares
+the same converter pipeline, profiles, and safe-mode semantics.
+
+## Installation
+
+```bash
+composer require markup-carve/carve-php:dev-main
+```
+
+> [!NOTE]
+> Carve-PHP currently ships only a `dev-main` branch (no tagged release yet), so it must be
+> required with an explicit `dev-main` constraint.
+
+## Basic Usage
+
+```php
+// You must load the helper before in e.g. AppView
+$this->addHelper('Markup.Carve', $optionalConfigArray);
+
+// In our template file we can now convert some Carve markup
+$string = <<<'TEXT'
+# Heading
+
+Some *bold* text and also some /italic/.
+
+A [link](https://example.com) and `inline code`.
+TEXT;
+
+echo $this->Carve->convert($string);
+```
+
+Carve uses visual mnemonics for inline formatting: `*bold*` for strong, `/italic/` for emphasis
+(the slashes lean like italic text), and `_underline_` for underline.
+
+## Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `safeMode` | `true` | Enable XSS protection - blocks dangerous URLs (javascript:, data:), filters unsafe attributes (onclick, etc.), and escapes raw HTML |
+| `xhtml` | `false` | Output XHTML-compatible markup (self-closing tags like `<br />`) |
+| `strict` | `false` | Throw exceptions on parse errors instead of silently handling them |
+| `profile` | `null` | Restrict which markup features are allowed |
+
+> [!NOTE]
+> Dangerous URL schemes (`javascript:`, `data:`, `vbscript:`, `file:`) are stripped by the
+> library's always-on baseline hardening, regardless of `safeMode`. Safe mode adds raw-HTML
+> escaping and attribute filtering on top.
+
+### Profiles
+
+Profiles let you restrict which Carve features are available, useful for user-generated content:
+
+| Profile | Use Case | Allows |
+|---------|----------|--------|
+| `'full'` | Trusted content | All features |
+| `'article'` | Blog posts | All formatting, no raw HTML |
+| `'comment'` | User comments | Basic formatting, nofollow links, no images/headings |
+| `'minimal'` | Chat/micro-posts | Text formatting only, no links/images |
+
+Example:
+```php
+// Restrict features for user-generated content
+$this->addHelper('Markup.Carve', [
+    'profile' => 'comment',
+]);
+```
+
+You can also create custom profiles using the `Carve\Profile` class.
+
+## CarveView - Render .carve Templates
+
+You can render `.carve` files directly as templates:
+
+```php
+// In your controller
+public function documentation(): void
+{
+    $this->viewBuilder()->setClassName('Markup.Carve');
+}
+```
+
+Create templates with `.carve` extension (e.g., `templates/Pages/documentation.carve`):
+
+```carve
+# Welcome, {{username}}!
+
+This page was rendered from a `.carve` template file.
+
+You can use all Carve features:
+
+- *Bold* and /italic/ text
+- [Links](https://example.com)
+- `Code blocks`
+```
+
+View variables are available for substitution using `{{varName}}` syntax.
+
+## Write Your Own Converter
+
+Implement the `CarveInterface` and configure it:
+
+```php
+// Configure
+'Carve' => [
+    'converter' => 'VendorName\PluginName\CustomCarve',
+],
+```
+
+This allows full customization of the Carve conversion process.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,3 +15,4 @@ Markup-to-HTML converters for various formats:
 - **[Markdown](Markdown.md)** - CommonMark/GFM support via league/commonmark
 - **[BBCode](Bbcode.md)** - Forum-style markup via mjohnson/decoda
 - **[Djot](Djot.md)** - Modern markup language via php-collective/djot
+- **[Carve](Carve.md)** - Post-Markdown markup language via markup-carve/carve-php

--- a/src/Carve/CarveInterface.php
+++ b/src/Carve/CarveInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Markup\Carve;
+
+interface CarveInterface {
+
+	/**
+	 * Convert Carve markup to HTML.
+	 *
+	 * Options:
+	 * - `safeMode`: Enable XSS protection - blocks dangerous URLs (javascript:, data:),
+	 *   filters unsafe attributes (onclick, etc.), and escapes raw HTML. Defaults to true.
+	 * - `xhtml`: Output XHTML-compatible markup (self-closing tags like <br />). Defaults to false.
+	 * - `strict`: Throw exceptions on parse errors. Defaults to false.
+	 * - `warnings`: Collect warnings during parsing. Defaults to false.
+	 * - `profile`: Profile name ('full', 'article', 'comment', 'minimal') or Profile instance
+	 *   to restrict which markup features are allowed. Defaults to null (all features).
+	 *
+	 * @param string $text
+	 * @param array<string, mixed> $options
+	 * @return string
+	 */
+	public function convert(string $text, array $options = []): string;
+
+}

--- a/src/Carve/CarveMarkup.php
+++ b/src/Carve/CarveMarkup.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Markup\Carve;
+
+use Cake\Core\InstanceConfigTrait;
+use Carve\CarveConverter;
+use Carve\Profile;
+
+/**
+ * Carve markup converter using markup-carve/carve-php.
+ *
+ * Carve is a post-Markdown lightweight markup language with visual mnemonics and
+ * human-centered design. The PHP implementation is a hard fork of djot-php, so it
+ * shares the same converter pipeline, profiles, and safe-mode semantics.
+ *
+ * @link https://github.com/markup-carve/carve Carve specification
+ * @link https://github.com/markup-carve/carve-php PHP implementation
+ */
+class CarveMarkup implements CarveInterface {
+
+	use InstanceConfigTrait;
+
+	/**
+	 * Cached converter, keyed by the hash of options used to build it.
+	 * Per-call options that differ from the cached key trigger a rebuild,
+	 * preventing a `safeMode=false` instance from serving a later call that
+	 * requested `safeMode=true` — a real risk in long-lived FPM/queue workers.
+	 *
+	 * @var \Carve\CarveConverter|null
+	 */
+	protected ?CarveConverter $converter = null;
+
+	/**
+	 * @var string|null
+	 */
+	protected ?string $converterKey = null;
+
+	/**
+	 * Default configuration.
+	 *
+	 * - `safeMode`: Enable XSS protection - blocks dangerous URLs (javascript:, data:),
+	 *   filters unsafe attributes (onclick, etc.), and escapes raw HTML. Defaults to true.
+	 * - `xhtml`: Output XHTML-compatible markup (self-closing tags like <br />). Defaults to false.
+	 * - `strict`: Throw exceptions on parse errors instead of silently handling them. Defaults to false.
+	 * - `warnings`: Collect warnings during parsing (accessible via converter). Defaults to false.
+	 * - `profile`: A Profile instance or profile name ('full', 'article', 'comment', 'minimal')
+	 *   to restrict which markup features are allowed. Defaults to null (all features allowed).
+	 *
+	 * @var array<string, mixed>
+	 */
+	protected array $_defaultConfig = [
+		'safeMode' => true,
+		'xhtml' => false,
+		'strict' => false,
+		'warnings' => false,
+		'profile' => null,
+	];
+
+	/**
+	 * @param array<string, mixed> $config
+	 */
+	public function __construct(array $config = []) {
+		$this->setConfig($config);
+	}
+
+	/**
+	 * @param string $text
+	 * @param array<string, mixed> $options
+	 *
+	 * @return string
+	 */
+	public function convert(string $text, array $options = []): string {
+		$options += $this->getConfig();
+
+		$converter = $this->converter($options);
+
+		return $converter->convert($text);
+	}
+
+	/**
+	 * @param array<string, mixed> $options
+	 *
+	 * @return \Carve\CarveConverter
+	 */
+	protected function converter(array $options): CarveConverter {
+		$key = md5(serialize($options));
+		if (!($this->converter instanceof CarveConverter) || $this->converterKey !== $key) {
+			$profile = $this->resolveProfile($options['profile'] ?? null);
+
+			$this->converter = new CarveConverter(
+				xhtml: $options['xhtml'] ?? false,
+				warnings: $options['warnings'] ?? false,
+				strict: $options['strict'] ?? false,
+				safeMode: $options['safeMode'] ?? true,
+				profile: $profile,
+			);
+			$this->converterKey = $key;
+		}
+
+		return $this->converter;
+	}
+
+	/**
+	 * Resolve a profile from configuration.
+	 *
+	 * @param \Carve\Profile|string|null $profile Profile instance, name, or null
+	 * @return \Carve\Profile|null
+	 */
+	protected function resolveProfile(Profile|string|null $profile): ?Profile {
+		if ($profile instanceof Profile) {
+			return $profile;
+		}
+
+		if ($profile === null) {
+			return null;
+		}
+
+		return match ($profile) {
+			'full' => Profile::full(),
+			'article' => Profile::article(),
+			'comment' => Profile::comment(),
+			'minimal' => Profile::minimal(),
+			default => null,
+		};
+	}
+
+}

--- a/src/View/CarveView.php
+++ b/src/View/CarveView.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Markup\View;
+
+use Cake\View\View;
+use Markup\Carve\CarveInterface;
+use Markup\Carve\CarveMarkup;
+
+/**
+ * CarveView allows rendering `.carve` template files directly.
+ *
+ * Carve is a post-Markdown lightweight markup language with visual mnemonics and
+ * human-centered design. This view class lets you use `.carve` files as templates
+ * that get converted to HTML.
+ *
+ * ## Usage
+ *
+ * In your controller:
+ * ```php
+ * public function viewClasses(): array
+ * {
+ *     return [CarveView::class];
+ * }
+ *
+ * public function documentation(): void
+ * {
+ *     $this->viewBuilder()->setClassName('Markup.Carve');
+ * }
+ * ```
+ *
+ * Then create templates with `.carve` extension:
+ * `templates/Pages/documentation.carve`
+ *
+ * ## Variable Substitution
+ *
+ * View variables are available for simple substitution using `{{varName}}` syntax:
+ * ```carve
+ * # Welcome, {{username}}!
+ *
+ * Your account was created on {{createdAt}}.
+ * ```
+ *
+ * ## Configuration
+ *
+ * Configure via `Configure::write('Carve', [...])` or pass options to the view:
+ * - `safeMode`: Enable XSS protection (default: true)
+ * - `converter`: Custom converter class implementing CarveInterface
+ */
+class CarveView extends View {
+
+	/**
+	 * File extension for Carve templates.
+	 *
+	 * @var string
+	 */
+	protected string $_ext = '.carve';
+
+	/**
+	 * @var \Markup\Carve\CarveInterface|null
+	 */
+	protected ?CarveInterface $_converter = null;
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	protected array $_defaultConfig = [
+		'safeMode' => true,
+		'converter' => CarveMarkup::class,
+	];
+
+	/**
+	 * Renders a Carve template file and converts it to HTML.
+	 *
+	 * @param string $templateFile The template file path.
+	 * @param array<string, mixed> $dataForView View variables.
+	 * @return string Rendered HTML output.
+	 */
+	protected function _evaluate(string $templateFile, array $dataForView): string {
+		$content = file_get_contents($templateFile);
+		if ($content === false) {
+			return '';
+		}
+
+		// Simple variable substitution using {{varName}} syntax
+		foreach ($dataForView as $key => $value) {
+			if (is_scalar($value) || (is_object($value) && method_exists($value, '__toString'))) {
+				$content = str_replace('{{' . $key . '}}', (string)$value, $content);
+			}
+		}
+
+		return $this->_getConverter()->convert($content);
+	}
+
+	/**
+	 * Get the Carve converter instance.
+	 *
+	 * @return \Markup\Carve\CarveInterface
+	 */
+	protected function _getConverter(): CarveInterface {
+		if ($this->_converter !== null) {
+			return $this->_converter;
+		}
+
+		/** @var class-string<\Markup\Carve\CarveInterface> $className */
+		$className = $this->getConfig('converter') ?? CarveMarkup::class;
+		$this->_converter = new $className($this->getConfig());
+
+		return $this->_converter;
+	}
+
+}

--- a/src/View/CarveView.php
+++ b/src/View/CarveView.php
@@ -2,6 +2,10 @@
 
 namespace Markup\View;
 
+use Cake\Core\Configure;
+use Cake\Event\EventManagerInterface;
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
 use Cake\View\View;
 use Markup\Carve\CarveInterface;
 use Markup\Carve\CarveMarkup;
@@ -67,6 +71,28 @@ class CarveView extends View {
 		'safeMode' => true,
 		'converter' => CarveMarkup::class,
 	];
+
+	/**
+	 * Constructor.
+	 *
+	 * Merges the global `Carve` Configure values as defaults so that app-level
+	 * settings (custom `converter`, `profile`, `safeMode`, ...) apply when
+	 * rendering `.carve` templates. Explicit view options still win.
+	 *
+	 * @param \Cake\Http\ServerRequest|null $request Request instance.
+	 * @param \Cake\Http\Response|null $response Response instance.
+	 * @param \Cake\Event\EventManagerInterface|null $eventManager Event manager instance.
+	 * @param array<string, mixed> $viewOptions View options.
+	 */
+	public function __construct(
+		?ServerRequest $request = null,
+		?Response $response = null,
+		?EventManagerInterface $eventManager = null,
+		array $viewOptions = [],
+	) {
+		$defaults = (array)Configure::read('Carve');
+		parent::__construct($request, $response, $eventManager, $viewOptions + $defaults);
+	}
 
 	/**
 	 * Renders a Carve template file and converts it to HTML.

--- a/src/View/DjotView.php
+++ b/src/View/DjotView.php
@@ -2,6 +2,10 @@
 
 namespace Markup\View;
 
+use Cake\Core\Configure;
+use Cake\Event\EventManagerInterface;
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
 use Cake\View\View;
 use Markup\Djot\DjotInterface;
 use Markup\Djot\DjotMarkup;
@@ -66,6 +70,28 @@ class DjotView extends View {
 		'safeMode' => true,
 		'converter' => DjotMarkup::class,
 	];
+
+	/**
+	 * Constructor.
+	 *
+	 * Merges the global `Djot` Configure values as defaults so that app-level
+	 * settings (custom `converter`, `profile`, `safeMode`, ...) apply when
+	 * rendering `.djot` templates. Explicit view options still win.
+	 *
+	 * @param \Cake\Http\ServerRequest|null $request Request instance.
+	 * @param \Cake\Http\Response|null $response Response instance.
+	 * @param \Cake\Event\EventManagerInterface|null $eventManager Event manager instance.
+	 * @param array<string, mixed> $viewOptions View options.
+	 */
+	public function __construct(
+		?ServerRequest $request = null,
+		?Response $response = null,
+		?EventManagerInterface $eventManager = null,
+		array $viewOptions = [],
+	) {
+		$defaults = (array)Configure::read('Djot');
+		parent::__construct($request, $response, $eventManager, $viewOptions + $defaults);
+	}
 
 	/**
 	 * Renders a djot template file and converts it to HTML.

--- a/src/View/DjotView.php
+++ b/src/View/DjotView.php
@@ -2,10 +2,6 @@
 
 namespace Markup\View;
 
-use Cake\Core\Configure;
-use Cake\Event\EventManagerInterface;
-use Cake\Http\Response;
-use Cake\Http\ServerRequest;
 use Cake\View\View;
 use Markup\Djot\DjotInterface;
 use Markup\Djot\DjotMarkup;
@@ -70,28 +66,6 @@ class DjotView extends View {
 		'safeMode' => true,
 		'converter' => DjotMarkup::class,
 	];
-
-	/**
-	 * Constructor.
-	 *
-	 * Merges the global `Djot` Configure values as defaults so that app-level
-	 * settings (custom `converter`, `profile`, `safeMode`, ...) apply when
-	 * rendering `.djot` templates. Explicit view options still win.
-	 *
-	 * @param \Cake\Http\ServerRequest|null $request Request instance.
-	 * @param \Cake\Http\Response|null $response Response instance.
-	 * @param \Cake\Event\EventManagerInterface|null $eventManager Event manager instance.
-	 * @param array<string, mixed> $viewOptions View options.
-	 */
-	public function __construct(
-		?ServerRequest $request = null,
-		?Response $response = null,
-		?EventManagerInterface $eventManager = null,
-		array $viewOptions = [],
-	) {
-		$defaults = (array)Configure::read('Djot');
-		parent::__construct($request, $response, $eventManager, $viewOptions + $defaults);
-	}
 
 	/**
 	 * Renders a djot template file and converts it to HTML.

--- a/src/View/Helper/CarveHelper.php
+++ b/src/View/Helper/CarveHelper.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Markup\View\Helper;
+
+use Cake\Core\Configure;
+use Cake\View\Helper;
+use Cake\View\View;
+use InvalidArgumentException;
+use Markup\Carve\CarveMarkup;
+
+/**
+ * CarveHelper for converting Carve markup to HTML in templates.
+ *
+ * Carve is a post-Markdown lightweight markup language with visual mnemonics and
+ * human-centered design.
+ *
+ * @link https://github.com/markup-carve/carve Carve specification
+ * @extends Helper<\Cake\View\View>
+ */
+class CarveHelper extends Helper {
+
+	/**
+	 * @var \Markup\Carve\CarveInterface|null
+	 */
+	protected $_converter;
+
+	/**
+	 * Default configuration.
+	 *
+	 * - `converter`: The converter class to use. Defaults to CarveMarkup.
+	 * - `debug`: Show conversion timing in HTML comments. Defaults to app debug setting.
+	 * - `safeMode`: Enable XSS protection. Defaults to true.
+	 * - `xhtml`: Output XHTML-compatible markup. Defaults to false.
+	 * - `profile`: Profile name ('full', 'article', 'comment', 'minimal') or Profile instance.
+	 *   Restricts which markup features are allowed. Defaults to null (all features).
+	 *
+	 * @var array<string, mixed>
+	 */
+	protected array $_defaultConfig = [
+		'converter' => CarveMarkup::class,
+		'debug' => null,
+		'safeMode' => true,
+		'xhtml' => false,
+		'profile' => null,
+	];
+
+	/**
+	 * @var float
+	 */
+	protected $_time = 0.0;
+
+	/**
+	 * Constructor
+	 *
+	 * @param \Cake\View\View $View The View this helper is being attached to.
+	 * @param array<string, mixed> $config Configuration settings for the helper.
+	 */
+	public function __construct(View $View, array $config = []) {
+		$defaults = (array)Configure::read('Carve');
+		parent::__construct($View, $config + $defaults);
+
+		if ($this->_config['debug'] === null) {
+			$this->_config['debug'] = Configure::read('debug');
+		}
+	}
+
+	/**
+	 * Convert Carve markup to HTML.
+	 *
+	 * Options:
+	 * - `safeMode`: Enable XSS protection (blocks dangerous URLs, filters attributes). Defaults to true.
+	 * - `xhtml`: Output XHTML-compatible markup. Defaults to false.
+	 * - `strict`: Throw exceptions on parse errors. Defaults to false.
+	 * - `profile`: Profile name or instance to restrict features ('comment', 'minimal', etc.).
+	 *
+	 * @param string $text Carve markup text.
+	 * @param array<string, mixed> $options Conversion options.
+	 * @return string Converted HTML.
+	 */
+	public function convert(string $text, array $options = []): string {
+		if ($this->_config['debug']) {
+			$this->_startTimer();
+		}
+		$html = $this->_getConverter()->convert($text, $options);
+		if ($this->_config['debug']) {
+			$html .= $this->_timeElapsedFormatted($this->_endTimer());
+		}
+
+		return trim($html);
+	}
+
+	/**
+	 * @return \Markup\Carve\CarveInterface
+	 */
+	protected function _getConverter() {
+		if ($this->_converter !== null) {
+			return $this->_converter;
+		}
+		/** @var class-string<\Markup\Carve\CarveInterface> $className */
+		$className = $this->_config['converter'];
+
+		if (!class_exists($className)) {
+			throw new InvalidArgumentException("Invalid converter class: {$className}");
+		}
+
+		$this->_converter = new $className($this->_config);
+
+		return $this->_converter;
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function _startTimer() {
+		$this->_time = microtime(true);
+	}
+
+	/**
+	 * @return float
+	 */
+	protected function _endTimer() {
+		$now = microtime(true);
+
+		return $now - $this->_time;
+	}
+
+	/**
+	 * @param float $time
+	 * @return string
+	 */
+	protected function _timeElapsedFormatted($time) {
+		return '<!-- ' . number_format($time * 1000, 3) . 'ms -->';
+	}
+
+}

--- a/tests/TestCase/Carve/CarveMarkupTest.php
+++ b/tests/TestCase/Carve/CarveMarkupTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Markup\Test\TestCase\Carve;
+
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use Markup\Carve\CarveMarkup;
+
+class CarveMarkupTest extends TestCase {
+
+	/**
+	 * @var \Markup\Carve\CarveMarkup
+	 */
+	protected $carve;
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		Configure::write('Carve', [
+			'debug' => false,
+		]);
+
+		$this->carve = new CarveMarkup();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		unset($this->carve);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertText(): void {
+		$text = <<<'TEXT'
+# Header
+
+My *bold* text with `code` and more.
+
+A paragraph [with links](http://example.com).
+
+## Header 2
+
+Foo bar.
+TEXT;
+
+		$result = $this->carve->convert($text);
+		$this->assertStringContainsString('<h1>Header</h1>', $result);
+		$this->assertStringContainsString('<strong>bold</strong>', $result);
+		$this->assertStringContainsString('<code>code</code>', $result);
+		$this->assertStringContainsString('<a href="http://example.com">with links</a>', $result);
+		$this->assertStringContainsString('<h2>Header 2</h2>', $result);
+		$this->assertStringContainsString('Foo bar.', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertEmphasis(): void {
+		// Carve uses slashes as a visual mnemonic for emphasis (italic).
+		$result = $this->carve->convert('Some /italic/ text.');
+		$this->assertStringContainsString('<em>italic</em>', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertSafeMode(): void {
+		$text = <<<'TEXT'
+# Header
+
+A link with [dangerous URL](javascript:alert('xss')).
+TEXT;
+
+		$result = $this->carve->convert($text, ['safeMode' => true]);
+		$this->assertStringContainsString('<h1>Header</h1>', $result);
+		// Safe mode should sanitize dangerous URLs
+		$this->assertStringNotContainsString('javascript:', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertWithoutSafeMode(): void {
+		$text = <<<'TEXT'
+# Header
+
+Some text with `<b>raw html</b>`{=html} inline.
+
+A link with [dangerous URL](javascript:alert('xss')).
+TEXT;
+
+		$result = $this->carve->convert($text, ['safeMode' => false]);
+		$this->assertStringContainsString('<h1>Header</h1>', $result);
+		// Without safe mode, raw HTML is passed through unescaped.
+		$this->assertStringContainsString('<b>raw html</b>', $result);
+		// Dangerous URL schemes are stripped by the library's always-on
+		// baseline hardening, independent of safe mode.
+		$this->assertStringNotContainsString('javascript:', $result);
+	}
+
+	/**
+	 * The converter must be rebuilt when per-call options differ from the
+	 * cached one. Otherwise the first call's safeMode would be pinned for the
+	 * lifetime of the instance — a real XSS regression vector under long-lived
+	 * FPM/queue workers.
+	 *
+	 * @return void
+	 */
+	public function testConverterRebuildsWhenOptionsChange(): void {
+		$text = 'Some `<b>raw html</b>`{=html} inline.';
+
+		// Without safe mode raw HTML passes through unescaped.
+		$first = $this->carve->convert($text, ['safeMode' => false]);
+		$this->assertStringContainsString('<b>raw html</b>', $first);
+
+		// A later call with safe mode must rebuild the converter and escape it.
+		$second = $this->carve->convert($text, ['safeMode' => true]);
+		$this->assertStringNotContainsString('<b>raw html</b>', $second);
+		$this->assertStringContainsString('&lt;b&gt;', $second);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertRawHtml(): void {
+		$text = <<<'TEXT'
+# Header
+
+Some text with `<b>raw html</b>`{=html} inline.
+TEXT;
+
+		$result = $this->carve->convert($text, ['safeMode' => false]);
+		$this->assertStringContainsString('<h1>Header</h1>', $result);
+		$this->assertStringContainsString('<b>raw html</b>', $result);
+	}
+
+}

--- a/tests/TestCase/View/CarveViewTest.php
+++ b/tests/TestCase/View/CarveViewTest.php
@@ -34,6 +34,7 @@ class CarveViewTest extends TestCase {
 		}
 
 		Configure::write('App.paths.templates', [$this->testTemplatePath]);
+		Configure::delete('Carve');
 
 		$this->view = new CarveView();
 		$this->view->disableAutoLayout();
@@ -119,6 +120,18 @@ CARVE;
 		$result = $this->view->render();
 
 		$this->assertStringNotContainsString('javascript:', $result);
+	}
+
+	/**
+	 * Global `Carve` Configure values must apply to direct `.carve` rendering.
+	 *
+	 * @return void
+	 */
+	public function testHonorsGlobalConfig(): void {
+		Configure::write('Carve', ['safeMode' => false]);
+
+		$view = new CarveView();
+		$this->assertFalse($view->getConfig('safeMode'));
 	}
 
 	/**

--- a/tests/TestCase/View/CarveViewTest.php
+++ b/tests/TestCase/View/CarveViewTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Markup\Test\TestCase\View;
+
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use Markup\Carve\CarveMarkup;
+use Markup\View\CarveView;
+use ReflectionClass;
+
+class CarveViewTest extends TestCase {
+
+	/**
+	 * @var \Markup\View\CarveView
+	 */
+	protected $view;
+
+	/**
+	 * @var string
+	 */
+	protected $testTemplatePath;
+
+	/**
+	 * setUp method
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->testTemplatePath = TMP . 'carve_test' . DS;
+		if (!is_dir($this->testTemplatePath)) {
+			mkdir($this->testTemplatePath, 0777, true);
+		}
+
+		Configure::write('App.paths.templates', [$this->testTemplatePath]);
+
+		$this->view = new CarveView();
+		$this->view->disableAutoLayout();
+	}
+
+	/**
+	 * tearDown method
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		// Clean up test templates
+		$files = glob($this->testTemplatePath . '*');
+		if ($files) {
+			foreach ($files as $file) {
+				unlink($file);
+			}
+		}
+		if (is_dir($this->testTemplatePath)) {
+			rmdir($this->testTemplatePath);
+		}
+
+		unset($this->view);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRenderBasicCarve(): void {
+		$templateContent = <<<'CARVE'
+# Hello World
+
+This is *bold* and `code`.
+CARVE;
+		file_put_contents($this->testTemplatePath . 'test.carve', $templateContent);
+
+		$this->view->setTemplatePath('');
+		$this->view->setTemplate('test');
+		$result = $this->view->render();
+
+		$this->assertStringContainsString('<h1>Hello World</h1>', $result);
+		$this->assertStringContainsString('<strong>bold</strong>', $result);
+		$this->assertStringContainsString('<code>code</code>', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRenderWithVariableSubstitution(): void {
+		$templateContent = <<<'CARVE'
+# Welcome, {{username}}!
+
+Your email is {{email}}.
+CARVE;
+		file_put_contents($this->testTemplatePath . 'vars.carve', $templateContent);
+
+		$this->view->setTemplatePath('');
+		$this->view->setTemplate('vars');
+		$this->view->set('username', 'John');
+		$this->view->set('email', 'john@example.com');
+		$result = $this->view->render();
+
+		$this->assertStringContainsString('Welcome, John!', $result);
+		$this->assertStringContainsString('john@example.com', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSafeModeEnabled(): void {
+		$templateContent = <<<'CARVE'
+# Test
+
+A [dangerous link](javascript:alert('xss')).
+CARVE;
+		file_put_contents($this->testTemplatePath . 'safe.carve', $templateContent);
+
+		$this->view->setConfig('safeMode', true);
+		$this->view->setTemplatePath('');
+		$this->view->setTemplate('safe');
+		$result = $this->view->render();
+
+		$this->assertStringNotContainsString('javascript:', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFileExtension(): void {
+		$view = new CarveView();
+		$reflection = new ReflectionClass($view);
+		$property = $reflection->getProperty('_ext');
+
+		$this->assertSame('.carve', $property->getValue($view));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDefaultConfig(): void {
+		$view = new CarveView();
+
+		$this->assertTrue($view->getConfig('safeMode'));
+		$this->assertSame(CarveMarkup::class, $view->getConfig('converter'));
+	}
+
+}

--- a/tests/TestCase/View/DjotViewTest.php
+++ b/tests/TestCase/View/DjotViewTest.php
@@ -34,7 +34,6 @@ class DjotViewTest extends TestCase {
 		}
 
 		Configure::write('App.paths.templates', [$this->testTemplatePath]);
-		Configure::delete('Djot');
 
 		$this->view = new DjotView();
 		$this->view->disableAutoLayout();
@@ -120,18 +119,6 @@ DJOT;
 		$result = $this->view->render();
 
 		$this->assertStringNotContainsString('javascript:', $result);
-	}
-
-	/**
-	 * Global `Djot` Configure values must apply to direct `.djot` rendering.
-	 *
-	 * @return void
-	 */
-	public function testHonorsGlobalConfig(): void {
-		Configure::write('Djot', ['safeMode' => false]);
-
-		$view = new DjotView();
-		$this->assertFalse($view->getConfig('safeMode'));
 	}
 
 	/**

--- a/tests/TestCase/View/DjotViewTest.php
+++ b/tests/TestCase/View/DjotViewTest.php
@@ -34,6 +34,7 @@ class DjotViewTest extends TestCase {
 		}
 
 		Configure::write('App.paths.templates', [$this->testTemplatePath]);
+		Configure::delete('Djot');
 
 		$this->view = new DjotView();
 		$this->view->disableAutoLayout();
@@ -119,6 +120,18 @@ DJOT;
 		$result = $this->view->render();
 
 		$this->assertStringNotContainsString('javascript:', $result);
+	}
+
+	/**
+	 * Global `Djot` Configure values must apply to direct `.djot` rendering.
+	 *
+	 * @return void
+	 */
+	public function testHonorsGlobalConfig(): void {
+		Configure::write('Djot', ['safeMode' => false]);
+
+		$view = new DjotView();
+		$this->assertFalse($view->getConfig('safeMode'));
 	}
 
 	/**

--- a/tests/TestCase/View/Helper/CarveHelperTest.php
+++ b/tests/TestCase/View/Helper/CarveHelperTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Markup\Test\TestCase\View\Helper;
+
+use Cake\Core\Configure;
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+use Markup\View\Helper\CarveHelper;
+
+class CarveHelperTest extends TestCase {
+
+	/**
+	 * @var \Markup\View\Helper\CarveHelper
+	 */
+	protected $helper;
+
+	/**
+	 * @var \Cake\Http\ServerRequest
+	 */
+	protected $request;
+
+	/**
+	 * setUp method
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		Configure::write('Carve', [
+			'debug' => false,
+		]);
+
+		$this->request = new ServerRequest();
+		$view = new View($this->request);
+		$this->helper = new CarveHelper($view);
+	}
+
+	/**
+	 * tearDown method
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		unset($this->helper);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvert() {
+		$text = <<<'TEXT'
+Some *bold* text.
+TEXT;
+
+		$result = $this->helper->convert($text);
+		$this->assertStringContainsString('<strong>bold</strong>', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertQuote() {
+		$text = <<<'TEXT'
+Some
+
+> quoted text
+>
+> -- Benjamin Franklin
+
+text.
+TEXT;
+
+		$result = $this->helper->convert($text);
+		$this->assertStringContainsString('<blockquote>', $result);
+		$this->assertStringContainsString('quoted text', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConvertDebug() {
+		$this->helper->setConfig('debug', true);
+
+		$text = <<<'TEXT'
+Some *bold* text.
+TEXT;
+
+		$result = $this->helper->convert($text);
+		$expected = '<!-- ';
+		$this->assertStringContainsString($expected, $result);
+		$expected = 'ms -->';
+		$this->assertStringContainsString($expected, $result);
+	}
+
+}


### PR DESCRIPTION
Adds a **Carve** markup formatter, mirroring the existing Djot integration.

[Carve](https://github.com/markup-carve/carve) is a post-Markdown lightweight markup language with visual mnemonics and human-centered design. The PHP implementation [`markup-carve/carve-php`](https://github.com/markup-carve/carve-php) is a hard fork of `djot-php`, so it shares the same converter pipeline, profiles, and safe-mode semantics - which lets the integration follow the Djot one closely.

## What's included

- `Markup\Carve\CarveInterface` + `Markup\Carve\CarveMarkup` converter, supporting `safeMode`, `xhtml`, `strict`, `warnings`, and `profile` options. The converter is rebuilt when per-call options differ from the cached one (same hardening as Djot, avoids a `safeMode=false` instance leaking into a later `safeMode=true` call under long-lived workers).
- `Markup\View\Helper\CarveHelper` for converting Carve markup in templates (reads global `Carve` config via `Configure`, supports the `debug` timing output).
- `Markup\View\CarveView` for rendering `.carve` template files directly, with `{{var}}` substitution (merges global `Carve` Configure values, same as `DjotView`).
- `Carve` config block in `config/app.example.php`.
- `docs/Carve.md` plus README and docs index entries; documented how `{{varName}}` substitution works (where variables are set, scalar/Stringable-only, substitution happens before conversion) for both Carve and Djot.
- Unit tests (converter), helper tests, and view tests.

## Syntax note

Carve uses visual mnemonics for inline formatting: `*bold*` -> strong, `/italic/` -> emphasis, `_x_` -> underline.

## Dependency note

`markup-carve/carve-php` is required as `^0.1.1` under `require-dev`, using the tagged release with the `MarkupCarve\Carve` namespace.
