### PR TITLE
Support media-embed 1.0 (immutable withAttribute API)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"cakephp/cakephp": "^5.1.1"
 	},
 	"require-dev": {
-		"dereuromark/media-embed": "^0.7",
+		"dereuromark/media-embed": "^1.0",
 		"fig-r/psr2r-sniffer": "dev-master",
 		"league/commonmark": "^1.5 || ^2.0",
 		"mjohnson/decoda": "^6.12",

--- a/src/Bbcode/Decoda/VideoFilter.php
+++ b/src/Bbcode/Decoda/VideoFilter.php
@@ -92,7 +92,7 @@ class VideoFilter extends AbstractFilter {
 			return null;
 		}
 
-		$MediaObject->setAttribute('width', '100%');
+		$MediaObject = $MediaObject->withAttribute('width', '100%');
 
 		return $MediaObject->getEmbedCode();
 	}

--- a/tests/TestCase/Bbcode/DecodaBbcodeTest.php
+++ b/tests/TestCase/Bbcode/DecodaBbcodeTest.php
@@ -87,7 +87,7 @@ Enjoy!
 TEXT;
 
 		$result = $this->bbcode->convert($text, ['escape' => false]);
-		$expected = 'Video Demo<br><iframe src="//www.youtube.com/embed/123?wmode=transparent" type="text/html" width="100%" height="295" frameborder="0" allowfullscreen></iframe><br>Enjoy!';
+		$expected = 'Video Demo<br><iframe src="//www.youtube.com/embed/123?wmode=transparent" type="text/html" title="YouTube embed" width="100%" height="295" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allow="fullscreen; picture-in-picture" frameborder="0" allowfullscreen></iframe><br>Enjoy!';
 		$this->assertSame($expected, $result);
 	}
 


### PR DESCRIPTION
Support media-embed 1.0 (immutable withAttribute API)

media-embed 1.0 replaced the mutable setAttribute() with the immutable
withAttribute() (returns a new instance). Update the Decoda video filter
to reassign the returned object, and bump the dev requirement to ^1.0.

The 1.0 embed output also carries richer default attributes (title,
loading=lazy, referrerpolicy, allow); the video conversion test
expectation is updated to match.
