### PR TITLE
Declare conflict with media-embed <1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
 		"php": ">=8.2",
 		"cakephp/cakephp": "^5.1.1"
 	},
+	"conflict": {
+		"dereuromark/media-embed": "<1.0"
+	},
 	"require-dev": {
 		"dereuromark/media-embed": "^1.0",
 		"fig-r/psr2r-sniffer": "dev-master",


### PR DESCRIPTION
Follow-up to media-embed 1.0 support (#21).

The Decoda video filter now uses the immutable `withAttribute()` API from media-embed 1.0 (the mutable `setAttribute()` was removed). Since media-embed is an optional integration (require-dev / suggest), the require-dev bump alone does not protect consumers who bring their own media-embed - they could install 0.7 against the new code and hit a runtime fatal.

Adding `conflict: { dereuromark/media-embed: "<1.0" }` makes Composer refuse a `<1.0` install up front with a clear message, instead of failing at runtime.